### PR TITLE
Refactor WriteDisk to take &mut instead of &

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,9 +115,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-bincode"
@@ -309,7 +309,7 @@ dependencies = [
  "attribute-derive-macro",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -325,7 +325,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "quote-use",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -336,7 +336,7 @@ checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backed_data"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm",
  "async-bincode",
@@ -500,7 +500,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -777,7 +777,7 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1001,7 +1001,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1061,7 +1061,7 @@ checksum = "13a1bcfb855c1f340d5913ab542e36f25a1c56f57de79022928297632435dec2"
 dependencies = [
  "attribute-derive",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1095,9 +1095,9 @@ checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "h2"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1506,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.156"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libm"
@@ -1707,7 +1707,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1780,7 +1780,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1965,7 +1965,7 @@ checksum = "a7b5abe3fe82fdeeb93f44d66a7b444dedf2e4827defb0a8e69c437b2de2ef94"
 dependencies = [
  "quote",
  "quote-use-macros",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1977,7 +1977,7 @@ dependencies = [
  "derive-where",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2035,7 +2035,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2069,9 +2069,9 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
 dependencies = [
  "base64",
  "bytes",
@@ -2107,7 +2107,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2295,7 +2295,7 @@ checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2466,9 +2466,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.74"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2480,23 +2480,26 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2532,7 +2535,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2584,7 +2587,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -2826,7 +2829,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
 
@@ -2860,7 +2863,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2918,16 +2921,37 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
-name = "windows-sys"
-version = "0.48.0"
+name = "windows-registry"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2936,7 +2960,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2945,22 +2969,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2969,21 +2978,15 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2993,21 +2996,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3023,21 +3014,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3047,37 +3026,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "zerocopy"
@@ -3096,7 +3053,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.74",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "backed_data"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Bennett Petzold <dansecob.dev@gmail.com>"]
 edition = "2021"
 rust-version = "1.80"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ success contacting the owner. The following options are under consideration:
 * Add descriptions to all examples, and refactor for clarity if necessary.
 * Ensure `adapters` has no race conditions that can cause program hang.
 * Trim the `BackedArray` methods. 
-* Consider refactoring WriteDisk to remove the need for runtime borrow checks in `mmap`.
 * Implement missing standard library traits (e.g. `[]` access).
 * Add array iterators that minimize memory usage by dropping backing stores when no longer borrowed.
 

--- a/examples/async_mmap.rs
+++ b/examples/async_mmap.rs
@@ -43,7 +43,7 @@ mod not_windows {
     pub async fn example() {
         let backing_file = temp_dir().join("backed_array_async_mmap");
 
-        let disk = SyncAsAsync::new(
+        let mut disk = SyncAsAsync::new(
             Mmap::try_from(backing_file.clone()).unwrap(),
             |x: SyncAsAsyncReadBg<ReadMmapCursor>| {
                 spawn_blocking(|| x.call());

--- a/examples/async_simd.rs
+++ b/examples/async_simd.rs
@@ -23,7 +23,7 @@ async fn main() {
     let backing_file = temp_dir().join("backed_array_async_simd");
     let data: HashMap<usize, usize> = (0..10_000).map(|x| (x, x * 2)).collect();
 
-    let disk = Plainfile::new(backing_file.clone());
+    let mut disk = Plainfile::new(backing_file.clone());
 
     // Create an adapter to run encoding and decoding in tokio's blocking
     // threadpool.

--- a/examples/mmap.rs
+++ b/examples/mmap.rs
@@ -42,7 +42,7 @@ mod not_windows {
 
         let backing_file = temp_dir().join("backed_array_mmap");
 
-        let disk = Mmap::try_from(backing_file.clone()).unwrap();
+        let mut disk = Mmap::try_from(backing_file.clone()).unwrap();
 
         let mut write_disk = disk.write_disk().unwrap();
 

--- a/src/directory/async_impl.rs
+++ b/src/directory/async_impl.rs
@@ -224,7 +224,7 @@ where
     where
         C: AsyncEncoder<<E::Disk as AsyncWriteDisk>::WriteDisk, Error: Context + Error, T = Self>,
     {
-        let disk: E::Disk = self
+        let mut disk: E::Disk = self
             .directory_root
             .join(META_FILE)
             .try_into()

--- a/src/directory/sync_impl.rs
+++ b/src/directory/sync_impl.rs
@@ -276,7 +276,7 @@ where
     where
         C: Encoder<<E::Disk as WriteDisk>::WriteDisk, Error: Context + Error, T = Self>,
     {
-        let disk: E::Disk = self
+        let mut disk: E::Disk = self
             .directory_root
             .join(META_FILE)
             .try_into()

--- a/src/entry/disks/custom.rs
+++ b/src/entry/disks/custom.rs
@@ -38,7 +38,7 @@ pub struct CustomRead<F>(pub F);
 /// ```
 /// use backed_data::entry::disks::{WriteDisk, custom::CustomWrite};
 ///
-/// let disk = CustomWrite(|| Ok(std::io::sink()));
+/// let mut disk = CustomWrite(|| Ok(std::io::sink()));
 /// let writer: std::io::Sink = disk.write_disk().unwrap();
 /// ```
 pub struct CustomWrite<F>(pub F);
@@ -57,7 +57,7 @@ pub struct CustomWrite<F>(pub F);
 ///     },
 /// };
 ///
-/// let disk = CustomSync(
+/// let mut disk = CustomSync(
 ///     CustomRead(|| Ok(std::io::empty())),
 ///     CustomWrite(|| Ok(std::io::sink()))
 /// );
@@ -86,7 +86,7 @@ where
 {
     type WriteDisk = W;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         (self.0)()
     }
 }
@@ -110,7 +110,7 @@ where
 {
     type WriteDisk = O;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         self.1.write_disk()
     }
 }
@@ -142,7 +142,7 @@ pub struct CustomAsyncRead<F>(pub F);
 /// use std::future::{Future, ready};
 /// use backed_data::entry::disks::{AsyncWriteDisk, custom::CustomAsyncWrite};
 ///
-/// let disk = CustomAsyncWrite(|| ready(Ok(smol::io::sink())));
+/// let mut disk = CustomAsyncWrite(|| ready(Ok(smol::io::sink())));
 /// let writer: &dyn Future<Output = std::io::Result<smol::io::Sink>> =
 ///     &disk.async_write_disk();
 /// ```
@@ -164,13 +164,15 @@ pub struct CustomAsyncWrite<F>(pub F);
 ///     },
 /// };
 ///
-/// let disk = CustomAsync(
+/// let mut disk = CustomAsync(
 ///     CustomAsyncRead(|| ready(Ok(smol::io::empty()))),
 ///     CustomAsyncWrite(|| ready(Ok(smol::io::sink())))
 /// );
 ///
-/// let reader: &dyn Future<Output = std::io::Result<smol::io::Empty>> =
-///     &disk.async_read_disk();
+/// {
+///     let reader: &dyn Future<Output = std::io::Result<smol::io::Empty>> =
+///         &disk.async_read_disk();
+/// }
 /// let writer: &dyn Future<Output = std::io::Result<smol::io::Sink>> =
 ///     &disk.async_write_disk();
 /// ```
@@ -200,7 +202,7 @@ where
 {
     type WriteDisk = W;
 
-    fn async_write_disk(&self) -> impl Future<Output = std::io::Result<Self::WriteDisk>> {
+    fn async_write_disk(&mut self) -> impl Future<Output = std::io::Result<Self::WriteDisk>> {
         (self.0)()
     }
 }
@@ -230,7 +232,7 @@ where
 {
     type WriteDisk = O;
 
-    fn async_write_disk(&self) -> impl Future<Output = std::io::Result<Self::WriteDisk>> {
+    fn async_write_disk(&mut self) -> impl Future<Output = std::io::Result<Self::WriteDisk>> {
         self.1.async_write_disk()
     }
 }
@@ -258,7 +260,7 @@ where
 ///     },
 /// };
 ///
-/// let disk = CustomFull(
+/// let mut disk = CustomFull(
 ///     CustomSync(
 ///         CustomRead(|| Ok(std::io::empty())),
 ///         CustomWrite(|| Ok(std::io::sink()))
@@ -271,8 +273,10 @@ where
 ///
 /// let sync_reader: std::io::Empty = disk.read_disk().unwrap();
 /// let sync_writer: std::io::Sink = disk.write_disk().unwrap();
-/// let async_reader: &dyn Future<Output = std::io::Result<smol::io::Empty>> =
-///     &disk.async_read_disk();
+/// {
+///     let async_reader: &dyn Future<Output = std::io::Result<smol::io::Empty>> =
+///         &disk.async_read_disk();
+/// }
 /// let async_writer: &dyn Future<Output = std::io::Result<smol::io::Sink>> =
 ///     &disk.async_write_disk();
 /// ```
@@ -300,7 +304,7 @@ where
 {
     type WriteDisk = O;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         self.0.write_disk()
     }
 }
@@ -334,7 +338,7 @@ where
 {
     type WriteDisk = O;
 
-    fn async_write_disk(&self) -> impl Future<Output = std::io::Result<Self::WriteDisk>> {
+    fn async_write_disk(&mut self) -> impl Future<Output = std::io::Result<Self::WriteDisk>> {
         self.1.async_write_disk()
     }
 }

--- a/src/entry/disks/encrypted.rs
+++ b/src/entry/disks/encrypted.rs
@@ -514,7 +514,7 @@ impl<B> EncryptedWriter<'_, B> {
 impl<'a, B: WriteDisk> WriteDisk for Encrypted<'a, B> {
     type WriteDisk = EncryptedWriter<'a, B::WriteDisk>;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         Ok(EncryptedWriter::new(
             self.inner.write_disk()?,
             self.secrets.clone(),
@@ -597,7 +597,7 @@ mod async_impl {
     impl<'a, B: WriteDisk, FE, FD> WriteDisk for AsyncEncrypted<'a, B, FE, FD> {
         type WriteDisk = EncryptedWriter<'a, B::WriteDisk>;
 
-        fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+        fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
             self.sync.write_disk()
         }
     }
@@ -826,7 +826,7 @@ mod async_impl {
     {
         type WriteDisk = AsyncEncryptedWriter<'a, B::WriteDisk, FE, R>;
 
-        async fn async_write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+        async fn async_write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
             let write_disk = self.inner.async_write_disk().await?;
             let handle_ptr: *const _ = &self.encrypt_handle;
             Ok(AsyncEncryptedWriter::new(

--- a/src/entry/disks/mod.rs
+++ b/src/entry/disks/mod.rs
@@ -28,7 +28,7 @@ pub trait ReadDisk {
 /// Produces storage that can be written to synchronously.
 pub trait WriteDisk {
     type WriteDisk: Write;
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk>;
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk>;
 }
 
 #[cfg(feature = "async")]
@@ -45,7 +45,7 @@ pub trait AsyncReadDisk {
 pub trait AsyncWriteDisk {
     type WriteDisk: AsyncWrite + Unpin;
     fn async_write_disk(
-        &self,
+        &mut self,
     ) -> impl Future<Output = std::io::Result<Self::WriteDisk>> + Send + Sync;
 }
 
@@ -56,9 +56,9 @@ impl<T: ReadDisk> ReadDisk for &T {
     }
 }
 
-impl<T: WriteDisk> WriteDisk for &T {
+impl<T: WriteDisk> WriteDisk for &mut T {
     type WriteDisk = T::WriteDisk;
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         T::write_disk(self)
     }
 }
@@ -74,10 +74,10 @@ impl<T: AsyncReadDisk + Send> AsyncReadDisk for &T {
 }
 
 #[cfg(feature = "async")]
-impl<T: AsyncWriteDisk + Send> AsyncWriteDisk for &T {
+impl<T: AsyncWriteDisk + Send> AsyncWriteDisk for &mut T {
     type WriteDisk = T::WriteDisk;
     fn async_write_disk(
-        &self,
+        &mut self,
     ) -> impl Future<Output = std::io::Result<Self::WriteDisk>> + Send + Sync {
         T::async_write_disk(self)
     }

--- a/src/entry/disks/plainfile.rs
+++ b/src/entry/disks/plainfile.rs
@@ -67,7 +67,7 @@ impl ReadDisk for Plainfile {
 impl WriteDisk for Plainfile {
     type WriteDisk = BufWriter<File>;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         Ok(BufWriter::new(
             File::options()
                 .write(true)
@@ -93,7 +93,7 @@ impl AsyncReadDisk for Plainfile {
 impl AsyncWriteDisk for Plainfile {
     type WriteDisk = futures::io::BufWriter<super::async_file::AsyncFile>;
 
-    async fn async_write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    async fn async_write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         Ok(futures::io::BufWriter::new(
             super::async_file::write_file(self.path.clone()).await?,
         ))

--- a/src/entry/disks/unbuffered.rs
+++ b/src/entry/disks/unbuffered.rs
@@ -62,7 +62,7 @@ impl ReadDisk for Unbuffered {
 impl WriteDisk for Unbuffered {
     type WriteDisk = File;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         File::options()
             .write(true)
             .create(true)
@@ -84,7 +84,7 @@ impl AsyncReadDisk for Unbuffered {
 impl AsyncWriteDisk for Unbuffered {
     type WriteDisk = super::async_file::AsyncFile;
 
-    async fn async_write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    async fn async_write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         super::async_file::write_file(self.path.clone()).await
     }
 }

--- a/src/entry/disks/write_unbuffered.rs
+++ b/src/entry/disks/write_unbuffered.rs
@@ -63,7 +63,7 @@ impl ReadDisk for WriteUnbuffered {
 impl WriteDisk for WriteUnbuffered {
     type WriteDisk = File;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         File::options()
             .write(true)
             .create(true)
@@ -87,7 +87,7 @@ impl AsyncReadDisk for WriteUnbuffered {
 impl AsyncWriteDisk for WriteUnbuffered {
     type WriteDisk = super::async_file::AsyncFile;
 
-    async fn async_write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    async fn async_write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         super::async_file::write_file(self.path.clone()).await
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -94,7 +94,7 @@ impl<'a> ReadDisk for CursorVec<'a> {
 impl<'a> WriteDisk for CursorVec<'a> {
     type WriteDisk = &'a mut Cursor<Vec<u8>>;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         let mut this = self.inner.lock().unwrap();
         this.get_mut().clear();
         this.rewind()?;
@@ -118,7 +118,7 @@ impl<'a> AsyncReadDisk for CursorVec<'a> {
 impl<'a> AsyncWriteDisk for CursorVec<'a> {
     type WriteDisk = &'a mut Vec<u8>;
 
-    async fn async_write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    async fn async_write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         let mut this = self.inner.lock().unwrap();
         this.get_mut().clear();
         this.rewind()?;
@@ -137,18 +137,6 @@ impl<'a> ReadDisk for &'a mut CursorVec<'a> {
     }
 }
 
-impl<'a> WriteDisk for &'a mut CursorVec<'a> {
-    type WriteDisk = &'a mut Cursor<Vec<u8>>;
-
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
-        let mut this = self.inner.lock().unwrap();
-        this.get_mut().clear();
-        this.rewind()?;
-        let this: *mut _ = this.deref_mut();
-        unsafe { Ok(&mut *this) }
-    }
-}
-
 #[cfg(feature = "async")]
 impl<'a> AsyncReadDisk for &mut CursorVec<'a> {
     type ReadDisk = &'a [u8];
@@ -157,19 +145,6 @@ impl<'a> AsyncReadDisk for &mut CursorVec<'a> {
         self.inner.lock().unwrap().rewind()?;
         let this: *const _ = &**self.inner.lock().unwrap().get_ref();
         Ok(unsafe { &*this })
-    }
-}
-
-#[cfg(feature = "async")]
-impl<'a> AsyncWriteDisk for &mut CursorVec<'a> {
-    type WriteDisk = &'a mut Vec<u8>;
-
-    async fn async_write_disk(&self) -> std::io::Result<Self::WriteDisk> {
-        let mut this = self.inner.lock().unwrap();
-        this.get_mut().clear();
-        this.rewind()?;
-        let this: *mut _ = this.get_mut();
-        unsafe { Ok(&mut *this) }
     }
 }
 
@@ -235,7 +210,7 @@ impl ReadDisk for OwnedCursorVec<'_> {
 impl<'a> WriteDisk for OwnedCursorVec<'a> {
     type WriteDisk = &'a mut Cursor<Vec<u8>>;
 
-    fn write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    fn write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         let mut this = self.inner.lock().unwrap();
         this.get_mut().clear();
         this.rewind()?;
@@ -259,7 +234,7 @@ impl<'a> AsyncReadDisk for OwnedCursorVec<'a> {
 impl<'a> AsyncWriteDisk for OwnedCursorVec<'a> {
     type WriteDisk = &'a mut Vec<u8>;
 
-    async fn async_write_disk(&self) -> std::io::Result<Self::WriteDisk> {
+    async fn async_write_disk(&mut self) -> std::io::Result<Self::WriteDisk> {
         let mut this = self.inner.lock().unwrap();
         this.get_mut().clear();
         this.rewind()?;


### PR DESCRIPTION
This makes sense from an API perspective -- it can't prevent another process from writing to the same file at the same time, but it can at least prevent this write races inside the program. This allows allows `mmap` to assert that there are never both write and read handles open in safe Rust code.